### PR TITLE
(FIX) Workaround fixing integration tests

### DIFF
--- a/.github/actions/ec2-github-runner/action.yml
+++ b/.github/actions/ec2-github-runner/action.yml
@@ -83,5 +83,5 @@ outputs:
       EC2 Instance Id of the created runner.
       The id is used to terminate the EC2 instance when the runner is not needed anymore.
 runs:
-  using: node16
+  using: node12
   main: ./dist/index.js

--- a/.github/actions/ec2-github-runner/action.yml
+++ b/.github/actions/ec2-github-runner/action.yml
@@ -83,5 +83,5 @@ outputs:
       EC2 Instance Id of the created runner.
       The id is used to terminate the EC2 instance when the runner is not needed anymore.
 runs:
-  using: node12
+  using: node16
   main: ./dist/index.js

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -65,6 +65,9 @@ jobs:
 
           echo "# Install Juju"
           snap install juju --channel=3.1/stable
+          
+          echo "# Install juju-crashdump"
+          snap install --classic juju-crashdump
 
           echo "# Install charmcraft"
           snap install charmcraft --classic

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -87,10 +87,14 @@ async def deploy_cos_lite(ops_test: OpsTest):
     )
 
     with ops_test.model_context(COS_MODEL_NAME):
-        await ops_test.model.deploy(  # type: ignore[union-attr]
-            entity_url="https://charmhub.io/cos-lite",
-            trust=True,
-        )
+        deploy_cos_lite_run_args = ["juju", "deploy", "cos-lite", "--trust"]
+        retcode, stdout, stderr = await ops_test.run(*deploy_cos_lite_run_args)
+        if retcode != 0:
+            raise RuntimeError(f"Error: {stderr}")
+        # await ops_test.model.deploy(  # type: ignore[union-attr]
+        #     entity_url="https://charmhub.io/cos-lite",
+        #     trust=True,
+        # )
         await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
             apps=[*ops_test.model.applications],  # type: ignore[union-attr]
             raise_on_error=False,

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -87,6 +87,8 @@ async def deploy_cos_lite(ops_test: OpsTest):
     )
 
     with ops_test.model_context(COS_MODEL_NAME):
+        # TODO: Remove below workaround and uncomment the proper deployment once
+        #       https://github.com/charmed-kubernetes/pytest-operator/issues/116 is fixed.
         deploy_cos_lite_run_args = ["juju", "deploy", "cos-lite", "--trust"]
         retcode, stdout, stderr = await ops_test.run(*deploy_cos_lite_run_args)
         if retcode != 0:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -43,11 +43,15 @@ class TestSDCoreBundle:
             ops_test: OpsTest
         """
         await self._deploy_sdcore_router(ops_test)
-        await ops_test.model.deploy(  # type: ignore[union-attr]
-            entity_url="https://charmhub.io/sdcore",
-            channel="latest/edge",
-            trust=True,
-        )
+        deploy_sd_core_run_args = ["juju", "deploy", "sd-core", "--trust", "--channel=edge"]
+        retcode, stdout, stderr = await ops_test.run(*deploy_sd_core_run_args)
+        if retcode != 0:
+            raise RuntimeError(f"Error: {stderr}")
+        # await ops_test.model.deploy(  # type: ignore[union-attr]
+        #     entity_url="https://charmhub.io/sdcore",
+        #     channel="latest/edge",
+        #     trust=True,
+        # )
 
         await self._create_cross_model_relation(
             ops_test,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -43,7 +43,10 @@ class TestSDCoreBundle:
             ops_test: OpsTest
         """
         await self._deploy_sdcore_router(ops_test)
-        deploy_sd_core_run_args = ["juju", "deploy", "sd-core", "--trust", "--channel=edge"]
+
+        # TODO: Remove below workaround and uncomment the proper deployment once
+        #       https://github.com/charmed-kubernetes/pytest-operator/issues/116 is fixed.
+        deploy_sd_core_run_args = ["juju", "deploy", "sdcore", "--trust", "--channel=edge"]
         retcode, stdout, stderr = await ops_test.run(*deploy_sd_core_run_args)
         if retcode != 0:
             raise RuntimeError(f"Error: {stderr}")


### PR DESCRIPTION
# Description

- Adds a workaround for [this issue](https://github.com/charmed-kubernetes/pytest-operator/issues/116)
- Installs `juju-crashdump` in the test env

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
