### PR TITLE
fix: Revert "chore(deps): update dependency pytest-asyncio to v0.23.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ mypy
 pep8-naming
 pyproject-flake8
 pytest
-pytest-asyncio==0.23.2
+pytest-asyncio==0.21.1
 pytest-operator
 requests
 types-PyYAML


### PR DESCRIPTION
Reverts canonical/sdcore-tests#128