### PR TITLE
chore: Rename bundle and charms following renaming in other projects

### DIFF
--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -52,14 +52,14 @@ async def configure_sdcore(ops_test: OpsTest):
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
 async def deploy_gnbsim(ops_test: OpsTest, configure_sdcore):
-    """Deploys `sdcore-gnbsim`.
+    """Deploys `sdcore-gnbsim-k8s`.
 
     Args:
         ops_test: OpsTest
         configure_sdcore: `configure_sdcore` fixture
     """
     await ops_test.model.deploy(  # type: ignore[union-attr]
-        "sdcore-gnbsim",
+        "sdcore-gnbsim-k8s",
         application_name="gnbsim",
         channel="latest/edge",
         trust=True,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -37,7 +37,7 @@ class TestSDCoreBundle:
         assert action_output["success"] == "true"
 
     async def _deploy_sdcore(self, ops_test: OpsTest):
-        """Deploys `sdcore` bundle.
+        """Deploys `sdcore-k8s` bundle.
 
         Args:
             ops_test: OpsTest
@@ -46,7 +46,7 @@ class TestSDCoreBundle:
 
         # TODO: Remove below workaround and uncomment the proper deployment once
         #       https://github.com/charmed-kubernetes/pytest-operator/issues/116 is fixed.
-        deploy_sd_core_run_args = ["juju", "deploy", "sdcore", "--trust", "--channel=edge"]
+        deploy_sd_core_run_args = ["juju", "deploy", "sdcore-k8s", "--trust", "--channel=edge"]
         retcode, stdout, stderr = await ops_test.run(*deploy_sd_core_run_args)
         if retcode != 0:
             raise RuntimeError(f"Error: {stderr}")
@@ -75,13 +75,13 @@ class TestSDCoreBundle:
 
     @staticmethod
     async def _deploy_sdcore_router(ops_test: OpsTest):
-        """Deploys `sdcore-router`.
+        """Deploys `sdcore-router-k8s`.
 
         Args:
             ops_test: OpsTest
         """
         await ops_test.model.deploy(  # type: ignore[union-attr]
-            "sdcore-router",
+            "sdcore-router-k8s",
             application_name="router",
             channel="latest/edge",
             trust=True,


### PR DESCRIPTION
# Description

Use the renamed bundles and charms following the recent renaming operation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
