### PR TITLE
fix: Pinnging juju version to latest working

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black
 flake8-docstrings
 flake8-builtins
 isort
-juju
+juju==3.3.0.0
 mypy
 pep8-naming
 pyproject-flake8


### PR DESCRIPTION
# Description

Pinning `juju` version to 3.3.0.0, which is last working. With 3.3.1.0 tests started failing because of 
```shell
 File "/home/ubuntu/github-runner/_work/sdcore-tests/sdcore-tests/.tox/integration/lib/python3.10/site-packages/juju/version.py", line 19, in <module>
    CLIENT_VERSION = re.search(r'\d+\.\d+\.\d+', open(VERSION_FILE_PATH).read().strip()).group()
FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/github-runner/_work/sdcore-tests/sdcore-tests/.tox/integration/lib/python3.10/site-packages/VERSION'
```

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
