### PR TITLE
chore: E2E tests improvements

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,8 +36,8 @@ jobs:
         if: always()
         run: |
           juju-crashdump -m sdcore
-          for pod in $(microk8s.kubectl -n sdcore get pods -o json | jq .items[].metadata.name | tr -d '"'); do
-            microk8s.kubectl -n sdcore logs $pod --all-containers > pod-$pod.log
+          for pod in $(sudo microk8s.kubectl -n sdcore get pods -o json | jq .items[].metadata.name | tr -d '"'); do
+           sudo  microk8s.kubectl -n sdcore logs $pod --all-containers > pod-$pod.log
           done
 
       - name: Archive juju crashdump

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -35,14 +35,8 @@ jobs:
       - name: Gather logs
         if: always()
         run: |
-          juju models
-          juju models --format=json | jq .models[].name
           juju-crashdump -m sdcore
           juju-crashdump -m cos-lite
-
-      - name: Debug
-        if: always()
-        run: ls -al
 
       - name: Archive juju crashdump
         if: always()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         run: tox -vve integration
 
       - name: Debug
-        run: juju crashdump
+        run: juju-crashdump
 
       - name: Archive juju crashdump
 #        if: failure()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -37,9 +37,8 @@ jobs:
         run: |
           juju models
           juju models --format=json | jq .models[].name
-#          for model in $(juju models --format=json | jq .models[].name); do
-#            sudo juju-crashdump -m $model
-#          done
+          juju-crashdump -m sdcore
+          juju-crashdump -m cos-lite
 
       - name: Debug
         if: always()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         if: always()
         run: |
           for model in $(juju models --format=json | jq .models[].name); do
-            juju-crashdump -m $model
+            sudo juju-crashdump -m $model
           done
 
       - name: Debug

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,9 +34,7 @@ jobs:
 
       - name: Gather logs
         if: always()
-        run: |
-          juju-crashdump -m sdcore
-          juju-crashdump -m cos-lite
+        run: juju-crashdump -m sdcore
 
       - name: Archive juju crashdump
         if: always()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -35,9 +35,11 @@ jobs:
       - name: Gather logs
         if: always()
         run: |
-          for model in $(juju models --format=json | jq .models[].name); do
-            sudo juju-crashdump -m $model
-          done
+          juju models
+          juju models --format=json | jq .models[].name
+#          for model in $(juju models --format=json | jq .models[].name); do
+#            sudo juju-crashdump -m $model
+#          done
 
       - name: Debug
         if: always()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,13 +33,10 @@ jobs:
         run: tox -vve integration
 
       - name: Debug
-        run: |
-          pwd
-          ls -al
-          sudo find / -name juju-crashdump-*.tar.xz
+        run: juju crashdump
 
       - name: Archive juju crashdump
-        if: failure()
+#        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: juju-crashdump

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,8 +32,14 @@ jobs:
       - name: Run integration tests
         run: tox -vve integration
 
+      - name: Gather logs
+        run: |
+          for model in $(juju models --format=json | jq .models[].name); do
+            juju-crashdump -m $model
+          done
+
       - name: Debug
-        run: juju-crashdump
+        run: ls -al
 
       - name: Archive juju crashdump
 #        if: failure()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,16 +33,18 @@ jobs:
         run: tox -vve integration
 
       - name: Gather logs
+        if: always()
         run: |
           for model in $(juju models --format=json | jq .models[].name); do
             juju-crashdump -m $model
           done
 
       - name: Debug
+        if: always()
         run: ls -al
 
       - name: Archive juju crashdump
-#        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: juju-crashdump

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -34,7 +34,11 @@ jobs:
 
       - name: Gather logs
         if: always()
-        run: juju-crashdump -m sdcore
+        run: |
+          juju-crashdump -m sdcore
+          for pod in $(microk8s.kubectl -n sdcore get pods -o json | jq .items[].metadata.name | tr -d '"'); do
+            microk8s.kubectl -n sdcore logs $pod --all-containers > pod-$pod.log
+          done
 
       - name: Archive juju crashdump
         if: always()
@@ -42,3 +46,10 @@ jobs:
         with:
           name: juju-crashdump
           path: juju-crashdump-*.tar.xz
+
+      - name: Archive k8s logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-logs
+          path: pod-*.log

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,6 +32,12 @@ jobs:
       - name: Run integration tests
         run: tox -vve integration
 
+      - name: Debug
+        run: |
+          pwd
+          ls -al
+          sudo find / -name juju-crashdump-*.tar.xz
+
       - name: Archive juju crashdump
         if: failure()
         uses: actions/upload-artifact@v4

--- a/tests/integration/juju_helper.py
+++ b/tests/integration/juju_helper.py
@@ -173,6 +173,7 @@ def set_application_config(model_name: str, application_name: str, config: dict)
                 raise JujuError(
                     f"Failed to set {model_key}={value} config for {application_name}"
                 ) from e
+    juju_wait_for_active_idle(model_name, 60)
 
 
 @contextmanager

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -154,6 +154,7 @@ def configure_sdcore():
     webui_client.create_subscriber(TEST_IMSI)
     webui_client.create_device_group(TEST_DEVICE_GROUP_NAME, [TEST_IMSI])
     webui_client.create_network_slice(TEST_NETWORK_SLICE_NAME, [TEST_DEVICE_GROUP_NAME])
+    # 5 seconds for the config to propagate
     time.sleep(5)
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import os
+import time
 from typing import Tuple
 
 import juju_helper
@@ -153,6 +154,7 @@ def configure_sdcore():
     webui_client.create_subscriber(TEST_IMSI)
     webui_client.create_device_group(TEST_DEVICE_GROUP_NAME, [TEST_IMSI])
     webui_client.create_network_slice(TEST_NETWORK_SLICE_NAME, [TEST_DEVICE_GROUP_NAME])
+    time.sleep(15)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -154,7 +154,7 @@ def configure_sdcore():
     webui_client.create_subscriber(TEST_IMSI)
     webui_client.create_device_group(TEST_DEVICE_GROUP_NAME, [TEST_IMSI])
     webui_client.create_network_slice(TEST_NETWORK_SLICE_NAME, [TEST_DEVICE_GROUP_NAME])
-    time.sleep(15)
+    time.sleep(5)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -49,7 +49,7 @@ class TestSDCoreBundle:
             application_name="gnbsim",
             unit_number=0,
             action_name="start-simulation",
-            timeout=300,
+            timeout=6 * 60,
         )
         assert action_output["success"] == "true"
 


### PR DESCRIPTION
# Description

This PR contains a bunch of minor changes contributing to stability and troubleshooting possibilities of e2e integration tests.
1. Fixes archiving of the Juju crashdump
2. Adds archiving of the k8s logs for all the SD-Core pods
3. Adds `juju_wait_for_active_idle` after any Juju action is executed
4. Adds 5 sec sleep after applying SD-Core configuration to allow propagation of the config

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
