### PR TITLE
chore: Replacing Canonical self-hosted runners with GH runners

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: [self-hosted, linux, x64, jammy, xlarge]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

As of January, 18th GH enterprise runners doubled their HW spec. After initial tests, they seem to perform better than the Canonical self-hosted runners. 
This PR changes the env for the E2E tests to GH-hosted runners again.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
