### PR TITLE
chore: Move to codespell and ruff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-To make contributions to this projec, you'll need a working [Juju development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this project, you'll need a working [Juju development setup](https://juju.is/docs/sdk/dev-setup).
 
 You can use the environments created by `tox` for development:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ line-length = 99
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
 extend-ignore = [
+    "D107",
     "D203",
     "D204",
     "D213",
@@ -27,7 +28,6 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,27 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107", "F401", "F811"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
 
 [tool.mypy]
 pretty = true
@@ -49,3 +51,6 @@ allow_redefinition = true
 [[tool.mypy.overrides]]
 module = ["ops.*"]
 ignore_missing_imports = true
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/requirements.in
+++ b/requirements.in
@@ -1,15 +1,11 @@
-black
-flake8-docstrings
-flake8-builtins
-isort
+codespell
 Jinja2
 juju
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
 requests
+ruff
 types-PyYAML
 types-requests
 types-setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -22,26 +20,20 @@ cffi==1.16.0
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.2.6
+    # via -r requirements.in
 cryptography==42.0.5
     # via paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
+exceptiongroup==1.2.0
+    # via
+    #   ipython
+    #   pytest
 executing==2.0.1
     # via stack-data
-flake8==7.0.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r requirements.in
-flake8-docstrings==1.7.0
-    # via -r requirements.in
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -54,8 +46,6 @@ ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.2
     # via ipdb
-isort==5.13.2
-    # via -r requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
@@ -74,13 +64,10 @@ markupsafe==2.1.5
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r requirements.in
 mypy-extensions==1.0.0
     # via
-    #   black
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
@@ -89,21 +76,14 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   black
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.13.3
-    # via -r requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
     # via pytest
 prompt-toolkit==3.0.43
@@ -121,14 +101,8 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
     # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.2.0
-    # via flake8
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -138,8 +112,6 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==7.0.0
-    # via -r requirements.in
 pyrfc3339==1.1
     # via
     #   juju
@@ -173,6 +145,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.7
+    # via -r requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -180,10 +154,13 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
+tomli==2.0.1
+    # via
+    #   ipdb
+    #   mypy
+    #   pytest
 toposort==1.10
     # via juju
 traitlets==5.14.1

--- a/tests/integration/juju_helper.py
+++ b/tests/integration/juju_helper.py
@@ -21,7 +21,7 @@ def juju_wait_for_active_idle(model_name: str, timeout: int, time_idle: int = 10
         time_idle(int): Time to wait after applications become Active-Idle
 
     Raises:
-        TimeoutError: Raised if applications do not become Active-Idle withing given time
+        TimeoutError: Raised if applications do not become Active-Idle within given time
     """
     now = time.time()
     with juju_context(model_name):

--- a/tests/integration/juju_helper.py
+++ b/tests/integration/juju_helper.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def juju_wait_for_active_idle(model_name: str, timeout: int, time_idle: int = 10):
-    """Waits for all application in a given model to be become Active-Idle.
+    """Wait for all application in a given model to be become Active-Idle.
 
     Args:
         model_name(str): Juju model name
@@ -47,7 +47,7 @@ def juju_wait_for_active_idle(model_name: str, timeout: int, time_idle: int = 10
 
 
 def get_application_address(model_name: str, application_name: str) -> str:
-    """Gets Juju application IP address.
+    """Get Juju application IP address.
 
     Args:
         model_name(str): Juju model name
@@ -68,7 +68,7 @@ def get_application_address(model_name: str, application_name: str) -> str:
 
 
 def get_unit_address(model_name: str, application_name: str, unit_number: int) -> str:
-    """Gets Juju application unit IP address.
+    """Get Juju application unit IP address.
 
     Args:
         model_name(str): Juju model name
@@ -93,7 +93,7 @@ def get_unit_address(model_name: str, application_name: str, unit_number: int) -
 def juju_run_action(
     model_name: str, application_name: str, unit_number: int, action_name: str, timeout: int = 60
 ) -> dict:
-    """Runs Juju action.
+    """Run Juju action.
 
     Args:
         model_name(str): Juju model name
@@ -120,7 +120,7 @@ def juju_run_action(
 
 
 def juju_status(app_or_unit_name: Optional[str] = None) -> dict:
-    """Returns status of the model, application or unit.
+    """Return status of the model, application or unit.
 
     Args:
         app_or_unit_name(str): Juju application or unit name. If not specified, status
@@ -135,7 +135,7 @@ def juju_status(app_or_unit_name: Optional[str] = None) -> dict:
 
 
 def set_model_config(model_name: str, config: dict):
-    """Sets Juju model config.
+    """Set Juju model config.
 
     Args:
         model_name(str): Juju model name
@@ -155,7 +155,7 @@ def set_model_config(model_name: str, config: dict):
 
 
 def set_application_config(model_name: str, application_name: str, config: dict):
-    """Sets Juju model config.
+    """Set Juju model config.
 
     Args:
         model_name(str): Juju model name
@@ -178,7 +178,7 @@ def set_application_config(model_name: str, application_name: str, config: dict)
 
 @contextmanager
 def juju_context(model_name: str):
-    """Allows changing currently active Juju model.
+    """Allow changing currently active Juju model.
 
     Args:
         model_name(str): Juju model name

--- a/tests/integration/terraform_helper.py
+++ b/tests/integration/terraform_helper.py
@@ -27,7 +27,7 @@ class TerraformError(Exception):
 
 class TerraformClient:
     def __init__(self, work_dir: str = os.getcwd()):
-        """Constructor for the TerraformClient.
+        """Construct the TerraformClient.
 
         Args:
             work_dir(str): Directory containing Terraform root module. Defaults to current working
@@ -40,7 +40,7 @@ class TerraformClient:
         self.work_dir = work_dir
 
     def init(self):
-        """Initializes the Terraform provider.
+        """Initialize the Terraform provider.
 
         Equivalent to `terraform init` CLI command.
 
@@ -56,7 +56,7 @@ class TerraformClient:
             ) from e
 
     def apply(self, auto_approve: Optional[bool] = True):
-        """Applies the Terraform plan based on the module.
+        """Apply the Terraform plan based on the module.
 
         Equivalent to `terraform apply` CLI command.
 
@@ -79,7 +79,7 @@ class TerraformClient:
 
     @staticmethod
     def _terraform_available() -> bool:
-        """Checks whether the Terraform executable is installed.
+        """Check whether the Terraform executable is installed.
 
         Returns:
             bool: Whether the Terraform executable is installed
@@ -87,7 +87,7 @@ class TerraformClient:
         return which(TERRAFORM_APP_NAME) is not None
 
     def _run_terraform_cmd(self, terraform_command: str, *args) -> int:
-        """Runs Terraform command.
+        """Run Terraform command.
 
         Args:
             terraform_command(str): Terraform command to execute

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -77,7 +77,7 @@ class TestSDCoreBundle:
         resp.raise_for_status()
 
     def _deploy_sdcore(self):
-        """Deploys the SD-Core Terraform module for testing.
+        """Deploy the SD-Core Terraform module for testing.
 
         SD-Core Terraform module contains:
         - sdcore-k8s Terraform module
@@ -92,7 +92,7 @@ class TestSDCoreBundle:
 
     @staticmethod
     def _generate_tfvars_file():
-        """Generates .tfvars file to configure Terraform deployment."""
+        """Generate .tfvars file to configure Terraform deployment."""
         jinja2_environment = Environment(loader=FileSystemLoader(f"{TERRAFORM_DIR}/"))
         template = jinja2_environment.get_template(f"{TFVARS_FILE}.j2")
         content = template.render(
@@ -104,7 +104,7 @@ class TestSDCoreBundle:
 
     @staticmethod
     def _get_nms_url() -> str:
-        """Gets the URL of the SD-Core NMS application from Traefik.
+        """Get the URL of the SD-Core NMS application from Traefik.
 
         Returns:
             str: URL of the SD-Core NMS application
@@ -120,7 +120,7 @@ class TestSDCoreBundle:
 
     @staticmethod
     async def _get_grafana_url_and_admin_password() -> Tuple[str, str]:
-        """Gets Grafana URL and admin password.
+        """Get Grafana URL and admin password.
 
         Returns:
             str: Grafana URL
@@ -138,7 +138,7 @@ class TestSDCoreBundle:
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
 def configure_sdcore():
-    """Configures Charmed SD-Core.
+    """Configure Charmed SD-Core.
 
     Configuration includes:
     - subscriber creation
@@ -161,7 +161,7 @@ def configure_sdcore():
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
 def configure_traefik_external_hostname() -> None:
-    """Configures external hostname for Traefik charm using its external IP and nip.io."""
+    """Configure external hostname for Traefik charm using its external IP and nip.io."""
     traefik_public_address = juju_helper.get_application_address(
         model_name=SDCORE_MODEL_NAME,
         application_name="traefik",

--- a/tests/integration/webui_helper.py
+++ b/tests/integration/webui_helper.py
@@ -48,7 +48,7 @@ NETWORK_SLICE_CONFIG = {
 
 class WebUI:
     def __init__(self, webui_ip: str) -> None:
-        """Constructor.
+        """Construct the WebUI class.
 
         Args:
             webui_ip (str): IP address of the WebUI application unit
@@ -56,7 +56,7 @@ class WebUI:
         self.webui_ip = webui_ip
 
     def create_subscriber(self, imsi: str) -> None:
-        """Creates a subscriber.
+        """Create a subscriber.
 
         Args:
             imsi (str): Subscriber's IMSI
@@ -68,7 +68,7 @@ class WebUI:
         logger.info(f"Created subscriber with IMSI {imsi}.")
 
     def create_device_group(self, device_group_name: str, imsis: list) -> None:
-        """Creates a device group.
+        """Create a device group.
 
         Args:
             device_group_name (str): Device group name
@@ -89,7 +89,7 @@ class WebUI:
         raise TimeoutError("Timed out creating device group.")
 
     def create_network_slice(self, network_slice_name: str, device_groups: list) -> None:
-        """Creates a network slice.
+        """Create a network slice.
 
         Args:
             network_slice_name (str): Network slice name

--- a/tox.ini
+++ b/tox.ini
@@ -24,15 +24,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
