### PR TITLE
chore: Add retries for simulation

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -159,7 +159,7 @@ def configure_sdcore():
     webui_client = WebUI(webui_ip_address)
     webui_client.create_subscriber(TEST_IMSI)
     webui_client.create_device_group(TEST_DEVICE_GROUP_NAME, [TEST_IMSI])
-    # webui_client.create_network_slice(TEST_NETWORK_SLICE_NAME, [TEST_DEVICE_GROUP_NAME])
+    webui_client.create_network_slice(TEST_NETWORK_SLICE_NAME, [TEST_DEVICE_GROUP_NAME])
     # 5 seconds for the config to propagate
     time.sleep(5)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -158,7 +158,7 @@ def configure_sdcore():
     webui_client = WebUI(webui_ip_address)
     webui_client.create_subscriber(TEST_IMSI)
     webui_client.create_device_group(TEST_DEVICE_GROUP_NAME, [TEST_IMSI])
-    webui_client.create_network_slice(TEST_NETWORK_SLICE_NAME, [TEST_DEVICE_GROUP_NAME])
+    # webui_client.create_network_slice(TEST_NETWORK_SLICE_NAME, [TEST_DEVICE_GROUP_NAME])
     # 5 seconds for the config to propagate
     time.sleep(5)
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -57,6 +57,7 @@ class TestSDCoreBundle:
                 break
             except AssertionError:
                 continue
+        assert False
 
     @pytest.mark.abort_on_fail
     async def test_given_external_hostname_configured_for_traefik_when_calling_sdcore_nms_then_configuration_tabs_are_available(  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -54,7 +54,7 @@ class TestSDCoreBundle:
             )
             try:
                 assert action_output["success"] == "true"
-                break
+                return
             except AssertionError:
                 continue
         assert False

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -44,14 +44,19 @@ class TestSDCoreBundle:
     async def test_given_sdcore_bundle_and_gnbsim_deployed_when_start_simulation_then_simulation_success_status_is_true(  # noqa: E501
         self, configure_sdcore
     ):
-        action_output = juju_helper.juju_run_action(
-            model_name=SDCORE_MODEL_NAME,
-            application_name="gnbsim",
-            unit_number=0,
-            action_name="start-simulation",
-            timeout=6 * 60,
-        )
-        assert action_output["success"] == "true"
+        for _ in range(5):
+            action_output = juju_helper.juju_run_action(
+                model_name=SDCORE_MODEL_NAME,
+                application_name="gnbsim",
+                unit_number=0,
+                action_name="start-simulation",
+                timeout=6 * 60,
+            )
+            try:
+                assert action_output["success"] == "true"
+                break
+            except AssertionError:
+                continue
 
     @pytest.mark.abort_on_fail
     async def test_given_external_hostname_configured_for_traefik_when_calling_sdcore_nms_then_configuration_tabs_are_available(  # noqa: E501


### PR DESCRIPTION
# Description

This PR adds up to 5 retries for the simulation. 
Simulation runs a single ping only. Any random networking problem will falsely fail the tests. After this change, simulation will have to fail 5 times in a row before we call the run failed. 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
