### PR TITLE
fix: Sync issues in the main pipeline

### DIFF
--- a/.github/workflows/ci_pipeline.yaml
+++ b/.github/workflows/ci_pipeline.yaml
@@ -35,6 +35,7 @@ jobs:
             echo ISSUE_EXISTS="False" >> $GITHUB_OUTPUT
           fi
       - name: Create issue
+        id: create-issue
         if: steps.check-issue.outputs.ISSUE_EXISTS == 'False'
         uses: dacbd/create-issue-action@v2.0.0
         with:
@@ -44,3 +45,6 @@ jobs:
             ### Context
             [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
+      - name: Sync Issues to JIRA
+        if: steps.create-issue.conclusion == 'success'
+        uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v0.0.1

--- a/.github/workflows/ci_pipeline.yaml
+++ b/.github/workflows/ci_pipeline.yaml
@@ -45,6 +45,10 @@ jobs:
             ### Context
             [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
-      - name: Sync Issues to JIRA
-        if: steps.create-issue.conclusion == 'success'
+
+  sync-issues:
+    runs-on: ubuntu-latest
+    needs: [ create-issue ]
+    steps:
+      - name: Sync issues to JIRA
         uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v0.0.1

--- a/.github/workflows/ci_pipeline.yaml
+++ b/.github/workflows/ci_pipeline.yaml
@@ -47,8 +47,6 @@ jobs:
             [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
 
   sync-issues:
-    runs-on: ubuntu-latest
     needs: [ create-issue ]
-    steps:
-      - name: Sync issues to JIRA
-        uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v0.0.1
+    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v0.0.1
+    secrets: inherit


### PR DESCRIPTION
# Description

Apparently the issues created by the `github-actions` user do not trigger the `issue created` event. As a result, the E2E failures are not reported in the backlog.
This PR adds a workaround for this problem - issue sync is called explicitly after issue creation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
