### PR TITLE
chore: Hardcoding SD-Core channel to edge

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,6 +16,7 @@ module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s?ref=v1.4"
 
   model_name = juju_model.sdcore.name
+  sdcore_channel = "1.4/edge"
   create_model = false
   deploy_cos = true
 


### PR DESCRIPTION
# Description

The default channel in the root Terraform modules now points to `1.4/beta`, but in the tests, we always want to pick up latest changes.
This PR hardcodes the SD-Core charms channel to `1.4/edge`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
