### PR TITLE
chore: Switches to Canonical self-hosted runners

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, linux, X64, large, jammy]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -55,7 +55,7 @@ class TestSDCoreBundle:
             try:
                 assert action_output["success"] == "true"
                 return
-            except AssertionError:
+            except [AssertionError, KeyError]:
                 continue
         assert False
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -38,7 +38,7 @@ class TestSDCoreBundle:
     @pytest.mark.abort_on_fail
     async def test_given_sdcore_terraform_module_when_deploy_then_status_is_active(self):
         self._deploy_sdcore()
-        juju_helper.juju_wait_for_active_idle(model_name=SDCORE_MODEL_NAME, timeout=1800)
+        juju_helper.juju_wait_for_active_idle(model_name=SDCORE_MODEL_NAME, timeout=1200)
 
     @pytest.mark.abort_on_fail
     async def test_given_sdcore_bundle_and_gnbsim_deployed_when_start_simulation_then_simulation_success_status_is_true(  # noqa: E501


### PR DESCRIPTION
# Description

Changes the default CI runner to Canonical's self-hosted runner

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
