### PR TITLE
fix: Fixes type error when catching exceptions

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -55,7 +55,7 @@ class TestSDCoreBundle:
             try:
                 assert action_output["success"] == "true"
                 return
-            except [AssertionError, KeyError]:
+            except (AssertionError, KeyError):
                 continue
         assert False
 


### PR DESCRIPTION
# Description

Fixes type error when catching exceptions:
`TypeError: catching classes that do not inherit from BaseException is not allowed`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
