### PR TITLE
fix: increase timeout value in integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -38,7 +38,7 @@ class TestSDCoreBundle:
     @pytest.mark.abort_on_fail
     async def test_given_sdcore_terraform_module_when_deploy_then_status_is_active(self):
         self._deploy_sdcore()
-        juju_helper.juju_wait_for_active_idle(model_name=SDCORE_MODEL_NAME, timeout=1200)
+        juju_helper.juju_wait_for_active_idle(model_name=SDCORE_MODEL_NAME, timeout=1500)
 
     @pytest.mark.abort_on_fail
     async def test_given_sdcore_bundle_and_gnbsim_deployed_when_start_simulation_then_simulation_success_status_is_true(  # noqa: E501


### PR DESCRIPTION
# Description

Sdcore integrations tests are failing in v1.4 branch. When we check the logs, some applications(NMS, router, traefik) appear in maintenance status when the tests are run. This PR increases the timeout to check the applications status.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
