### PR TITLE
feat: add TLS integration to the NMS

### DIFF
--- a/tests/integration/nms_helper.py
+++ b/tests/integration/nms_helper.py
@@ -63,7 +63,7 @@ class Nms:
         """
         SUBSCRIBER_CONFIG["UeId"] = imsi
         url = f"https://{self.nms_ip}:5000/api/subscriber/imsi-{imsi}"
-        response = requests.post(url=url, data=json.dumps(SUBSCRIBER_CONFIG))
+        response = requests.post(url=url, data=json.dumps(SUBSCRIBER_CONFIG), verify=False)
         response.raise_for_status()
         logger.info(f"Created subscriber with IMSI {imsi}.")
 
@@ -76,7 +76,7 @@ class Nms:
         """
         DEVICE_GROUP_CONFIG["imsis"] = imsis
         url = f"https://{self.nms_ip}:5000/config/v1/device-group/{device_group_name}"
-        response = requests.post(url, json=DEVICE_GROUP_CONFIG)
+        response = requests.post(url, json=DEVICE_GROUP_CONFIG, verify=False)
         response.raise_for_status()
         now = time.time()
         timeout = 5
@@ -97,7 +97,7 @@ class Nms:
         """
         NETWORK_SLICE_CONFIG["site-device-group"] = device_groups
         url = f"https://{self.nms_ip}:5000/config/v1/network-slice/{network_slice_name}"
-        response = requests.post(url, json=NETWORK_SLICE_CONFIG)
+        response = requests.post(url, json=NETWORK_SLICE_CONFIG, verify=False)
         response.raise_for_status()
         now = time.time()
         timeout = 5

--- a/tests/integration/nms_helper.py
+++ b/tests/integration/nms_helper.py
@@ -62,7 +62,7 @@ class Nms:
             imsi (str): Subscriber's IMSI
         """
         SUBSCRIBER_CONFIG["UeId"] = imsi
-        url = f"http://{self.nms_ip}:5000/api/subscriber/imsi-{imsi}"
+        url = f"https://{self.nms_ip}:5000/api/subscriber/imsi-{imsi}"
         response = requests.post(url=url, data=json.dumps(SUBSCRIBER_CONFIG))
         response.raise_for_status()
         logger.info(f"Created subscriber with IMSI {imsi}.")
@@ -75,7 +75,7 @@ class Nms:
             imsis (list): List of IMSIs to be included in the device group
         """
         DEVICE_GROUP_CONFIG["imsis"] = imsis
-        url = f"http://{self.nms_ip}:5000/config/v1/device-group/{device_group_name}"
+        url = f"https://{self.nms_ip}:5000/config/v1/device-group/{device_group_name}"
         response = requests.post(url, json=DEVICE_GROUP_CONFIG)
         response.raise_for_status()
         now = time.time()
@@ -96,7 +96,7 @@ class Nms:
             device_groups (list): List of device groups to be included in the network slice
         """
         NETWORK_SLICE_CONFIG["site-device-group"] = device_groups
-        url = f"http://{self.nms_ip}:5000/config/v1/network-slice/{network_slice_name}"
+        url = f"https://{self.nms_ip}:5000/config/v1/network-slice/{network_slice_name}"
         response = requests.post(url, json=NETWORK_SLICE_CONFIG)
         response.raise_for_status()
         now = time.time()

--- a/tests/integration/nms_helper.py
+++ b/tests/integration/nms_helper.py
@@ -81,7 +81,7 @@ class Nms:
         now = time.time()
         timeout = 5
         while time.time() - now <= timeout:
-            if requests.get(url).json():
+            if requests.get(url, verify=False).json():
                 logger.info(f"Created device group {device_group_name}.")
                 return
             else:
@@ -102,7 +102,7 @@ class Nms:
         now = time.time()
         timeout = 5
         while time.time() - now <= timeout:
-            if requests.get(url).json():
+            if requests.get(url, verify=False).json():
                 logger.info(f"Created network slice {network_slice_name}.")
                 return
             else:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -70,9 +70,9 @@ class TestSDCoreBundle:
         self, configure_traefik_external_hostname
     ):
         nms_url = self._get_nms_url()
-        network_configuration_resp = requests.get(f"{nms_url}/network-configuration")
+        network_configuration_resp = requests.get(f"{nms_url}/network-configuration", verify=False)
         network_configuration_resp.raise_for_status()
-        subscribers_resp = requests.get(f"{nms_url}/subscribers")
+        subscribers_resp = requests.get(f"{nms_url}/subscribers", verify=False)
         subscribers_resp.raise_for_status()
 
     @pytest.mark.abort_on_fail


### PR DESCRIPTION
# Description

After integrating with TLS certificates interface, the NMS is served on https. This PR updates the address used to reach the NMS on the integration tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
