### PR TITLE
chore: Uses 1.5/edge for the tests

### DIFF
--- a/terraform/integration_tests.auto.tfvars.j2
+++ b/terraform/integration_tests.auto.tfvars.j2
@@ -1,1 +1,2 @@
 sdcore_model_name = "{{ sdcore_model_name }}"
+ran_model_name    = "{{ ran_model_name }}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,25 +9,27 @@ module "sdcore-router" {
   source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform?ref=v1.5"
 
   model      = juju_model.sdcore.name
+  channel    = "1.5/edge"
   depends_on = [juju_model.sdcore]
 }
 
 module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s?ref=v1.5"
 
-  model = juju_model.sdcore.name
-
-  depends_on = [module.sdcore-router]
+  model          = juju_model.sdcore.name
+  sdcore_channel = "1.5/edge"
+  depends_on     = [module.sdcore-router]
 }
 
 resource "juju_model" "ran-simulator" {
-  name = "ran"
+  name = var.ran_model_name
 }
 
 module "gnbsim" {
   source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
 
   model      = juju_model.ran-simulator.name
+  channel    = "1.5/edge"
   depends_on = [module.sdcore-router]
 }
 
@@ -64,10 +66,10 @@ resource "juju_integration" "gnbsim-nms" {
 }
 
 module "cos" {
-  source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
-  model_name               = "cos-lite"
-  deploy_cos_configuration = true
-  cos_configuration_config = {
+  source                    = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
+  model_name                = "cos-lite"
+  deploy_cos_configuration  = true
+  cos_configuration_config  = {
     git_repo                = "https://github.com/canonical/sdcore-cos-configuration"
     git_branch              = "main"
     grafana_dashboards_path = "grafana_dashboards/sdcore/"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,7 +2,13 @@
 # See LICENSE file for licensing details.
 
 variable "sdcore_model_name" {
-  description = "Name of Juju model to deploy application to."
+  description = "Name of Juju model to deploy SD-Core applications to."
   type        = string
   default     = "sdcore"
+}
+
+variable "ran_model_name" {
+  description = "Name of Juju model to deploy RAN simulator to."
+  type        = string
+  default     = "ran"
 }

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -117,6 +117,7 @@ class TestSDCoreBundle:
         template = jinja2_environment.get_template(f"{TFVARS_FILE}.j2")
         content = template.render(
             sdcore_model_name=SDCORE_MODEL_NAME,
+            ran_model_name=RAN_MODEL_NAME,
         )
         with open(f"{TERRAFORM_DIR}/{TFVARS_FILE}", mode="w") as tfvars:
             tfvars.write(content)


### PR DESCRIPTION
# Description

After changing the default channel in the Terraform modules to `1.5/stable` the E2E tests would test the same thing over and over again. This PR changes the channel to `1.5/edge` to make sure we're testing the latest stuff.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
