### PR TITLE
chore: bump juju version to 3.6/stable

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-          juju-channel: 3.5/stable
+          juju-channel: 3.6/stable
           provider: microk8s
           channel: 1.31-strict/stable
           microk8s-addons: "hostpath-storage dns metallb:10.0.0.2-10.0.0.10"


### PR DESCRIPTION
# Description

Bump juju to the latest stable release: 3.6/stable.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
