### PR TITLE
fix: Changes the default-base of a Juju model to Noble

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,6 +3,10 @@
 
 resource "juju_model" "sdcore" {
   name = var.sdcore_model_name
+
+  config = {
+    default-base = "noble"
+  }
 }
 
 module "sdcore-router" {
@@ -22,6 +26,10 @@ module "sdcore" {
 
 resource "juju_model" "ran-simulator" {
   name = var.ran_model_name
+
+  config = {
+    default-base = "noble"
+  }
 }
 
 module "gnbsim" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,7 +5,7 @@ resource "juju_model" "sdcore" {
   name = var.sdcore_model_name
 
   config = {
-    default-base = "noble"
+    default-base = "ubuntu@24.04"
   }
 }
 
@@ -28,7 +28,7 @@ resource "juju_model" "ran-simulator" {
   name = var.ran_model_name
 
   config = {
-    default-base = "noble"
+    default-base = "ubuntu@24.04"
   }
 }
 


### PR DESCRIPTION
# Description

Changes the default-base of a Juju model to Noble

Thanks to this change, Juju will fetch 24.04 charms regardless of the version of the host system

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
