### PR TITLE
chore: Improves stability of the E2E tests

### DIFF
--- a/.github/workflows/ci_pipeline.yaml
+++ b/.github/workflows/ci_pipeline.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
   schedule:
     - cron: '0 2 * * *'
 

--- a/.github/workflows/ci_pipeline.yaml
+++ b/.github/workflows/ci_pipeline.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   push:
+    branches:
+      - main
   schedule:
     - cron: '0 2 * * *'
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -86,6 +86,10 @@ jobs:
           for pod in $(sudo microk8s.kubectl -n ran get pods -o json | jq .items[].metadata.name | tr -d '"'); do
             sudo  microk8s.kubectl -n ran logs $pod --all-containers > ran-$pod.log
           done
+          for pod in $(sudo microk8s.kubectl -n kube-system get pods -o json | jq .items[].metadata.name | tr -d '"'); do
+            sudo  microk8s.kubectl -n kube-system logs $pod --all-containers > kube-system-$pod.log
+            sudo  microk8s.kubectl -n kube-system describe $pod --all-containers > kube-system-$pod.describe
+          done
 
       - name: Archive juju crashdump
         if: failure()
@@ -102,3 +106,5 @@ jobs:
           path: |
             sdcore-*.log
             ran-*.log
+            kube-system-*.log
+            kube-system-*.describe

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -88,7 +88,7 @@ jobs:
           done
           for pod in $(sudo microk8s.kubectl -n kube-system get pods -o json | jq .items[].metadata.name | tr -d '"'); do
             sudo  microk8s.kubectl -n kube-system logs $pod --all-containers > kube-system-$pod.log
-            sudo  microk8s.kubectl -n kube-system describe $pod --all-containers > kube-system-$pod.describe
+            sudo  microk8s.kubectl -n kube-system describe $pod > kube-system-$pod.describe
           done
 
       - name: Archive juju crashdump

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,6 +29,9 @@ module "sdcore" {
   nrf_config = {
     log-level = "debug"
   }
+  nrf_resources = {
+    nrf-image = "gmerold/sdcore-nrf:1.6.1"
+  }
   nssf_config = {
     log-level = "debug"
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,21 +1,21 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-resource "juju_model" "sdcore" {
+data "juju_model" "sdcore" {
   name = var.sdcore_model_name
 }
 
 module "sdcore-router" {
   source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform"
 
-  model      = juju_model.sdcore.name
-  depends_on = [juju_model.sdcore]
+  model      = data.juju_model.sdcore.name
+  depends_on = [data.juju_model.sdcore]
 }
 
 module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s"
 
-  model = juju_model.sdcore.name
+  model = data.juju_model.sdcore.name
 
   amf_config = {
     log-level = "debug"
@@ -54,20 +54,20 @@ module "sdcore" {
   depends_on = [module.sdcore-router]
 }
 
-resource "juju_model" "ran-simulator" {
+data "juju_model" "ran-simulator" {
   name = var.ran_model_name
 }
 
 module "gnbsim" {
   source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
 
-  model      = juju_model.ran-simulator.name
+  model      = data.juju_model.ran-simulator.name
 
   depends_on = [module.sdcore-router]
 }
 
 resource "juju_integration" "gnbsim-amf" {
-  model = juju_model.ran-simulator.name
+  model = data.juju_model.ran-simulator.name
 
   application {
     name     = module.gnbsim.app_name
@@ -80,7 +80,7 @@ resource "juju_integration" "gnbsim-amf" {
 }
 
 resource "juju_integration" "gnbsim-nms" {
-  model = juju_model.ran-simulator.name
+  model = data.juju_model.ran-simulator.name
 
   application {
     name     = module.gnbsim.app_name
@@ -104,7 +104,7 @@ module "cos" {
 }
 
 resource "juju_integration" "prometheus-remote-write" {
-  model = juju_model.sdcore.name
+  model = data.juju_model.sdcore.name
 
   application {
     name     = module.sdcore.grafana_agent_app_name
@@ -117,7 +117,7 @@ resource "juju_integration" "prometheus-remote-write" {
 }
 
 resource "juju_integration" "loki-logging" {
-  model = juju_model.sdcore.name
+  model = data.juju_model.sdcore.name
 
   application {
     name     = module.sdcore.grafana_agent_app_name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,9 +29,6 @@ module "sdcore" {
   nrf_config = {
     log-level = "debug"
   }
-  nrf_resources = {
-    nrf-image = "gmerold/sdcore-nrf:1.6.1"
-  }
   nssf_config = {
     log-level = "debug"
   }

--- a/tests/integration/juju_helper.py
+++ b/tests/integration/juju_helper.py
@@ -12,6 +12,19 @@ from typing import Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
+def create_model(model_name: str):
+    """Create Juju models.
+
+    Args:
+        model_name(str): Juju model name
+    """
+    create_model_cmd = ["juju", "add-model", model_name]
+    try:
+        check_output(create_model_cmd)
+    except CalledProcessError as e:
+        raise JujuError(f"Failed to create Juju model: {model_name}") from e
+
+
 def juju_wait_for_active_idle(model_name: str, timeout: int, time_idle: int = 10):
     """Wait for all application in a given model to be become Active-Idle.
 

--- a/tests/integration/juju_helper.py
+++ b/tests/integration/juju_helper.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_model(model_name: str):
-    """Create Juju models.
+    """Create a Juju model.
 
     Args:
         model_name(str): Juju model name

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -96,7 +96,7 @@ class TestSDCoreBundle:
                     url=request_url, auth=HTTPBasicAuth(username="admin", password=grafana_passwd)
                 )
                 resp.raise_for_status()
-            except requests.exceptions.ConnectionError:
+            except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError):
                 logger.warning("Connection error. Retrying...")
                 retries += 1
         assert False

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -33,6 +33,8 @@ NMS_CREDENTIALS_LABEL = "NMS_LOGIN"
 class TestSDCoreBundle:
     @classmethod
     def setup_class(cls):
+        juju_helper.create_model(SDCORE_MODEL_NAME)
+        juju_helper.create_model(RAN_MODEL_NAME)
         juju_helper.set_model_config(
             model_name=SDCORE_MODEL_NAME,
             config={"update-status-hook-interval": "1m"},

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -100,6 +100,7 @@ class TestSDCoreBundle:
                 logger.warning(resp.text)
                 logger.warning("======================================================================")
                 resp.raise_for_status()
+                return
             except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError):
                 logger.warning("Connection error. Retrying...")
                 retries += 1

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -95,6 +95,10 @@ class TestSDCoreBundle:
                 resp = requests.get(
                     url=request_url, auth=HTTPBasicAuth(username="admin", password=grafana_passwd)
                 )
+                logger.warning("======================================================================")
+                logger.warning(resp.status_code)
+                logger.warning(resp.text)
+                logger.warning("======================================================================")
                 resp.raise_for_status()
             except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError):
                 logger.warning("Connection error. Retrying...")
@@ -157,6 +161,7 @@ class TestSDCoreBundle:
             unit_number=0,
             action_name="get-admin-password",
         )
+        logger.warning(f"Grafana output: {action_output}")
         return action_output["url"], action_output["admin-password"]
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -54,7 +54,7 @@ class TestSDCoreBundle:
         if not username or not password:
             raise Exception("NMS credentials not found.")
         configure_sdcore(username, password)
-        juju_helper.juju_wait_for_active_idle(model_name=RAN_MODEL_NAME, timeout=300)
+        juju_helper.juju_wait_for_active_idle(model_name=RAN_MODEL_NAME, timeout=300, time_idle=30)
         action_output = juju_helper.juju_run_action(
             model_name=RAN_MODEL_NAME,
             application_name="gnbsim",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -67,7 +67,7 @@ class TestSDCoreBundle:
                 assert action_output["success"] == "true"
                 return
             except (AssertionError, KeyError) as e:
-                logger.warning("Error when running simulation: %s. Retrying...", str(e))
+                logger.warning("Error when running simulation: %s. Retrying...", e)
         assert False
 
     @pytest.mark.abort_on_fail


### PR DESCRIPTION
# Description

- Adds retry around the simulation to eliminate random issues with triggering Juju action
- Adds retry around fetching Grafana dashboard to prevent random connection issues
- Creates Juju models for Core and RAN outside the TF module to prevent random provider failures when creating the models
- Increases time between applying network configuration and starting the simulation to `30s` to give Core time to propagate config properly
- Gathers logs and describes for `kube-system` Pod to improve troubleshooting

With all these changes I was able to get 15 successful runs in a row: https://github.com/canonical/sdcore-tests/actions/runs/13832359090

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
