### PR TITLE
feat: use Canonical K8s

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -28,11 +28,19 @@ jobs:
           cat << EOF | sudo k8s bootstrap --file -
           containerd-base-dir: /opt/containerd
           cluster-config:
+            network:
+              enabled: true
+            dns:
+              enabled: true
+            load-balancer:
+              enabled: true
+              cidrs:
+              - 10.0.0.2-10.0.0.10
+            local-storage:
+              enabled: true
             annotations:
               k8sd/v1alpha1/cilium/sctp/enabled: true
           EOF
-          sudo k8s enable network dns load-balancer local-storage
-          sudo k8s set load-balancer.cidrs="10.0.0.2-10.0.0.10"
           sudo k8s status --wait-ready --timeout 5m
           mkdir -p ~/.kube
           sudo k8s config > ~/.kube/config


### PR DESCRIPTION
# Description

This PR replaces `microk8s` with Canonical K8s in end-to-end tests.
Note: _Clean environment_ (removal of created models) is necessary to avoid _Post checkout_ (destroy of controller) the job getting stuck

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
